### PR TITLE
Additional Tests Based on PLI Course Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,3 @@ out/
 *.tsbuildinfo
 *.vsix
 .DS_Store
-
-code-blocks-lang-ref
-code-blocks-prog-guide
-failed-code-blocks
-PLI-course-sample-code

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ out/
 **/syntaxes/pli.merged.json
 *.tsbuildinfo
 *.vsix
+.DS_Store
+
+code-blocks-lang-ref
+code-blocks-prog-guide
+failed-code-blocks
+PLI-course-sample-code

--- a/packages/language/src/pli.langium
+++ b/packages/language/src/pli.langium
@@ -507,10 +507,11 @@ DeclaredItem: level=NUMBER? (element=DeclaredVariable | element='*' | '(' items+
 
 type NamedElement = DeclaredVariable | DoType3Variable | ProcedureStatement;
 type NamedType = DefineAliasStatement;
+type OrdinalType = DefineOrdinalStatement;
 
 DeclaredVariable: name=ID;
 
-DeclarationAttribute: InitialAttribute | DateAttribute | HandleAttribute | DefinedAttribute | PictureAttribute | EnvironmentAttribute | DimensionsDataAttribute | ValueAttribute | ValueListFromAttribute | ValueListAttribute | ValueRangeAttribute | ComputationDataAttribute | EntryAttribute | LikeAttribute | TypeAttribute;
+DeclarationAttribute: InitialAttribute | DateAttribute | HandleAttribute | DefinedAttribute | PictureAttribute | EnvironmentAttribute | DimensionsDataAttribute | ValueAttribute | ValueListFromAttribute | ValueListAttribute | ValueRangeAttribute | ComputationDataAttribute | EntryAttribute | LikeAttribute | TypeAttribute | OrdinalTypeAttribute;
 
 DateAttribute: 'DATE' ('(' pattern=STRING_TERM ')')?;
 
@@ -521,6 +522,8 @@ PictureAttribute: ('PICTURE' | 'WIDEPIC' | 'PIC') picture=STRING_TERM?;
 DimensionsDataAttribute: ('DIMENSION' | 'DIM')? dimensions=Dimensions;
 
 TypeAttribute: 'TYPE' (type=[NamedType:ID] | '(' type=[NamedType:ID] ')');
+
+OrdinalTypeAttribute: 'ORDINAL' (type=[OrdinalType:ID] | '(' type=[OrdinalType:ID] ')') byvalue?='BYVALUE';
 
 ComputationDataAttribute: type=DataAttributeType dimensions=Dimensions?;
 

--- a/packages/language/src/pli.langium
+++ b/packages/language/src/pli.langium
@@ -660,7 +660,7 @@ terminal fragment NUM: /([0-9][0-9_]*(\.[0-9_]+)?)|(\.[0-9_]+)/;
 terminal fragment FULL_NUM: NUM MANTISSA?;
 terminal fragment MANTISSA: /[eEsSdDqQ][-+]?[0-9]+/;
 // This terminal combines WRAPPED_NUM and normal strings
-terminal STRING_TERM: /("(""|\\.|[^"\\])*"|'(''|\\.|[^'\\])*')([xX]|[aA]|[eE]|[xX][uU]|[xX][nN]|[bB]4|[bB]3|[bB][xX]|[bB]|[gG][xX]|[gG]|[uU][xX]|[wW][xX]|[xX]|[iI])*/;
+terminal STRING_TERM: /("(""|\\.|[^"\\])*"|'(''|\\.|[^'\\])*')([xX][nN]|[xX][uU]|[xX]|[aA]|[eE]|[bB]4|[bB]3|[bB][xX]|[bB]|[gG][xX]|[gG]|[uU][xX]|[wW][xX]|[iI])*/;
 
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/packages/language/src/pli.langium
+++ b/packages/language/src/pli.langium
@@ -511,7 +511,7 @@ type OrdinalType = DefineOrdinalStatement;
 
 DeclaredVariable: name=ID;
 
-DeclarationAttribute: InitialAttribute | DateAttribute | HandleAttribute | DefinedAttribute | PictureAttribute | EnvironmentAttribute | DimensionsDataAttribute | ValueAttribute | ValueListFromAttribute | ValueListAttribute | ValueRangeAttribute | ComputationDataAttribute | EntryAttribute | LikeAttribute | TypeAttribute | OrdinalTypeAttribute;
+DeclarationAttribute: InitialAttribute | DateAttribute | HandleAttribute | DefinedAttribute | PictureAttribute | EnvironmentAttribute | DimensionsDataAttribute | ValueAttribute | ValueListFromAttribute | ValueListAttribute | ValueRangeAttribute | ReturnsAttribute | ComputationDataAttribute | EntryAttribute | LikeAttribute | TypeAttribute | OrdinalTypeAttribute;
 
 DateAttribute: 'DATE' ('(' pattern=STRING_TERM ')')?;
 
@@ -523,7 +523,15 @@ DimensionsDataAttribute: ('DIMENSION' | 'DIM')? dimensions=Dimensions;
 
 TypeAttribute: 'TYPE' (type=[NamedType:ID] | '(' type=[NamedType:ID] ')');
 
+// TODO @montymxb Jan. 24th, 2025: This may be too strict w/ regards to byvalue after, I suspect that we can pass much more there
 OrdinalTypeAttribute: 'ORDINAL' (type=[OrdinalType:ID] | '(' type=[OrdinalType:ID] ')') byvalue?='BYVALUE';
+
+/**
+ * Used to specify the attribute of a value that is returned (slightly different from `ReturnsOption`).
+ * Order of contained attributes is not a factor, consider it a set, so duplicates are ignored as well.
+ * All data attrs are valid + aligned/unaligned + non-data attributes BYVALUE/BYADDR, DATE, VALUELIST, and VALUERANGE (see pg. 134 lang-ref 6.1)
+ */
+ReturnsAttribute: 'RETURNS' '(' (attrs+=(ComputationDataAttribute | DateAttribute | ValueListAttribute | ValueRangeAttribute))* ')';
 
 ComputationDataAttribute: type=DataAttributeType dimensions=Dimensions?;
 

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -653,9 +653,7 @@ describe("PL/I Parsing tests", () => {
 
     test("External declaration with returns 'byvalue fixed type'", async () => {
         const doc: LangiumDocument<PliProgram> = await parseStmts(`
- dcl xyz BIN(31);
- dcl my_external
-        ext('my_external')
+ dcl my_external ext('my_external')
         entry( 
             pointer byvalue,
             returns ( fixed byvalue bin(31) )
@@ -688,6 +686,17 @@ describe("PL/I Parsing tests", () => {
  return(0);
  end P6;
     `);
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
+
+    test('align in returns attributes is valid as well', async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
+ dcl my_external ext('my_external')
+        entry( 
+            returns ( aligned byvalue bin(7) fixed )
+        );
+        `);
         expect(doc.parseResult.lexerErrors).toHaveLength(0);
         expect(doc.parseResult.parserErrors).toHaveLength(0);
     });

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -653,7 +653,6 @@ describe("PL/I Parsing tests", () => {
 
     test("External declaration with returns 'byvalue fixed type'", async () => {
         const doc: LangiumDocument<PliProgram> = await parseStmts(`
- MAINPR: procedure options(MAIN);
  dcl xyz BIN(31);
  dcl my_external
         ext('my_external')
@@ -662,15 +661,34 @@ describe("PL/I Parsing tests", () => {
             returns ( fixed byvalue bin(31) )
         )
         options ( nodescriptor );
-
- end MAINPR;
         `);
         expect(doc.parseResult.lexerErrors).toHaveLength(0);
         expect(doc.parseResult.parserErrors).toHaveLength(0);
     });
 
-    // TODO @montymxb Jan. 24th, 2025
-    // - test w/ multiple duplicate attrs, should still work
-    // - test w/ different orderings, should also still work
-    // - 
+    test('Procedures w/ aligned & unaligned attributes', async () => {
+        // regular parseStmts but with a body that has a procedure w/ align & unaligned attributes
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
+ P1: proc returns( bit(4) aligned );
+ return(0);
+ end P1;
+ P2: proc returns( bit(4) unaligned );
+ return(0);
+ end P2;
+ P3: proc returns( bit(4) aligned aligned );
+ return(0);
+ end P3;
+ P4: proc returns( bit(4) unaligned unaligned );
+ return(0);
+ end P4;
+ P5: proc returns( aligned bit(4) );
+ return(0);
+ end P5;
+ P6: proc returns( unaligned bit(4) unaligned );
+ return(0);
+ end P6;
+    `);
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 });

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -617,8 +617,6 @@ describe("PL/I Parsing tests", () => {
      */
     test('parse returns ordinal by value', async () => {
         const doc: LangiumDocument<PliProgram> = await parseStmts(`
- testpackage: package;
-
  define ordinal day (
     Monday,
     Tuesday,
@@ -629,12 +627,10 @@ describe("PL/I Parsing tests", () => {
     Sunday
  ) prec(15);
 
- /* should be able to parse return w/ ordinal correctly */
+ // should be able to parse return w/ ordinal correctly
  get_day: proc() returns(ordinal day byvalue);
     return( Friday );
  end get_day;
-
- end testpackage;
         `);
         expect(doc.parseResult.lexerErrors).toHaveLength(0);
         expect(doc.parseResult.parserErrors).toHaveLength(0);
@@ -654,4 +650,27 @@ describe("PL/I Parsing tests", () => {
         expect(doc.parseResult.lexerErrors).toHaveLength(0);
         expect(doc.parseResult.parserErrors).toHaveLength(0);
     });
+
+    test("External declaration with returns 'byvalue fixed type'", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
+ MAINPR: procedure options(MAIN);
+ dcl xyz BIN(31);
+ dcl my_external
+        ext('my_external')
+        entry( 
+            pointer byvalue,
+            returns ( fixed byvalue bin(31) )
+        )
+        options ( nodescriptor );
+
+ end MAINPR;
+        `);
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
+
+    // TODO @montymxb Jan. 24th, 2025
+    // - test w/ multiple duplicate attrs, should still work
+    // - test w/ different orderings, should also still work
+    // - 
 });

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -641,14 +641,14 @@ describe("PL/I Parsing tests", () => {
     });
 
     /**
-     * Verifies that numbers like '010101'xn are parsable
+     * Verifies that hex fixed-point constants like '010101'xn (or xu) are parsable
      */
-    // TODO rename this one
-    test('parses xn hex vals', async () => {
+    test('parses xn|xu binary fixed point constants', async () => {
         const doc: LangiumDocument<PliProgram> = await parseStmts(`
  MAINPR: procedure options (main);
     dcl x fixed bin(31) init(0);
     x = '0000ffff'xn;
+    x = '0000ffff'xu;
  end MAINPR;
         `);
         expect(doc.parseResult.lexerErrors).toHaveLength(0);

--- a/packages/language/test/parsing.test.ts
+++ b/packages/language/test/parsing.test.ts
@@ -19,75 +19,75 @@ let parse: ReturnType<typeof parseHelper<PliProgram>>;
 let parseStmts: ReturnType<typeof parseHelper<PliProgram>>;
 
 beforeAll(async () => {
-  services = createPliServices(EmptyFileSystem);
-  parse = parseHelper<PliProgram>(services.pli);
+    services = createPliServices(EmptyFileSystem);
+    parse = parseHelper<PliProgram>(services.pli);
 
-  /**
-   * Helper function to parse a string of PL/I statements,
-   * wrapping them in a procedure to ensure they are valid
-   */
-  parseStmts = (input: string) => {
-    return parse(` STARTPR: PROCEDURE OPTIONS (MAIN);
+    /**
+     * Helper function to parse a string of PL/I statements,
+     * wrapping them in a procedure to ensure they are valid
+     */
+    parseStmts = (input: string) => {
+        return parse(` STARTPR: PROCEDURE OPTIONS (MAIN);
 ${input}
  end STARTPR;`);
-  };
+    };
 
-  // activate the following if your linking test requires elements from a built-in library, for example
-  await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
+    // activate the following if your linking test requires elements from a built-in library, for example
+    await services.shared.workspace.WorkspaceManager.initializeWorkspace([]);
 });
 
 describe("PL/I Parsing tests", () => {
-  // // Handle as validation error
-  // test.fails('empty program', async () => {
-  //     const doc: LangiumDocument<PliProgram> = await parse(``);
-  //     expect(doc.parseResult.lexerErrors).toHaveLength(0);
-  //     expect(doc.parseResult.parserErrors).toHaveLength(0);
-  // });
+    // // Handle as validation error
+    // test.fails('empty program', async () => {
+    //     const doc: LangiumDocument<PliProgram> = await parse(``);
+    //     expect(doc.parseResult.lexerErrors).toHaveLength(0);
+    //     expect(doc.parseResult.parserErrors).toHaveLength(0);
+    // });
 
-  test("empty program w/ null statement", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`;`);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+    test("empty program w/ null statement", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`;`);
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  // TODO @montymxb this should pass according to the docs, but doesn't work in practice
-  // test('empty program w/ null %statement', async () => {
-  //     const doc: LangiumDocument<PliProgram> = await parseStmts(`%;`);
-  //     expect(doc.parseResult.lexerErrors).toHaveLength(0);
-  //     expect(doc.parseResult.parserErrors).toHaveLength(0);
-  // });
+    // TODO @montymxb this should pass according to the docs, but doesn't work in practice
+    // test('empty program w/ null %statement', async () => {
+    //     const doc: LangiumDocument<PliProgram> = await parseStmts(`%;`);
+    //     expect(doc.parseResult.lexerErrors).toHaveLength(0);
+    //     expect(doc.parseResult.parserErrors).toHaveLength(0);
+    // });
 
-  test("Hello World Program", async () => {
-    const doc = await parse(`
+    test("Hello World Program", async () => {
+        const doc = await parse(`
  AVERAGE: PROCEDURE OPTIONS (MAIN);
    /* Test characters: ^[] € */
    /* AVERAGE_GRADE = SUM / 5; */
    PUT LIST ('PROGRAM TO COMPUTE AVERAGE');
  END AVERAGE;`);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
-
-  describe("Procedures", () => {
-    test("Simple procedure", async () => {
-      const doc: LangiumDocument<PliProgram> = await parse(`
-    P1: procedure;
-    end P1;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
     });
 
-    test("Procedure w/ alternate entry point", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    describe("Procedures", () => {
+        test("Simple procedure", async () => {
+            const doc: LangiumDocument<PliProgram> = await parse(`
+    P1: procedure;
+    end P1;`);
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
+
+        test("Procedure w/ alternate entry point", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
     P1: procedure;
     B: entry; // secondary entry point into this procedure
     end P1;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Procedure with call", async () => {
-      const doc: LangiumDocument<PliProgram> = await parse(`
+        test("Procedure with call", async () => {
+            const doc: LangiumDocument<PliProgram> = await parse(`
  Control: procedure options(main);
   call A('ok'); // invoke the 'A' subroutine
  end Control;
@@ -95,12 +95,12 @@ describe("PL/I Parsing tests", () => {
  declare VAR1 char(3);
  put skip list(VAR1);
  end A;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Simple recursive procedure w/ recursive stated before returns", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Simple recursive procedure w/ recursive stated before returns", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  Fact: proc (Input) recursive returns (fixed bin(31));
   dcl Input fixed bin(15);
   if Input <= 1 then
@@ -108,12 +108,12 @@ describe("PL/I Parsing tests", () => {
   else
   return( Input*Fact(Input-1) );
  end Fact;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Simple recursive procedure w/ recursive stated after returns", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Simple recursive procedure w/ recursive stated after returns", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  Fact: proc (Input) returns (fixed bin(31)) recursive;
   dcl Input fixed bin(15);
   if Input <= 1 then
@@ -121,36 +121,36 @@ describe("PL/I Parsing tests", () => {
   else
   return( Input*Fact(Input-1) );
  end Fact;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Procedures w/ Order & Reorder options", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Procedures w/ Order & Reorder options", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  P1: proc Options(Order);
  end P1;
  P2: proc Options( Reorder );
  end P2;
  call P1;
  call P2;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Procedure w/ Reorder option & Returns", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Procedure w/ Reorder option & Returns", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  Double: proc (Input) Options(Reorder) returns(fixed bin(31));
   declare Input fixed bin(15);
   return( Input * 2);
  end Double;
  declare X fixed bin(31);
  X = Double(5);`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Recursive - Returns - Options for a Procedure in various permutations", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Recursive - Returns - Options for a Procedure in various permutations", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  // returns - options - recursive
  F1: proc (Input) returns (fixed bin(31)) Options(Order) recursive;
   dcl Input fixed bin(15);
@@ -196,12 +196,12 @@ describe("PL/I Parsing tests", () => {
   return( Input*F5(Input-1) );
  end F5;
  `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Options Separate by Commas & Spaces", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Options Separate by Commas & Spaces", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
     P1: proc Options( Order, Reorder, Recursive );
     end P1;
     P2: proc Options( Order Reorder Recursive);
@@ -210,12 +210,12 @@ describe("PL/I Parsing tests", () => {
     end P3;
     P4: proc Options(Order, Reorder Recursive);
     end P4;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Complex recursive procedure", async () => {
-      const doc: LangiumDocument<PliProgram> = await parse(`
+        test("Complex recursive procedure", async () => {
+            const doc: LangiumDocument<PliProgram> = await parse(`
  START: procedure options (main);
  dcl I fixed bin(15);
  I=1; call A;
@@ -232,43 +232,43 @@ describe("PL/I Parsing tests", () => {
  Out: end A;
  end Start;
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
-  });
-
-  // tests for labels
-  describe("Label Tests", () => {
-    test("empty label, null statement", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(` main:;`);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
     });
 
-    test("Declared label", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(
-        ` declare Label_x label;`,
-      );
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+    // tests for labels
+    describe("Label Tests", () => {
+        test("empty label, null statement", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(` main:;`);
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Label assignment", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Declared label", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(
+                ` declare Label_x label;`,
+            );
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
+
+        test("Label assignment", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare Label_x label;
  Label_a:;
  Label_x = Label_a; // label assignments
  go to Label_x; // jump to label
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
     });
-  });
 
-  // tests fro declarations
-  describe("Declaration tests", () => {
-    test("simple char declarations", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    // tests fro declarations
+    describe("Declaration tests", () => {
+        test("simple char declarations", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare UserA character (15); // 15 character var
  declare UserB character (15) varying; // varying
  declare UserC character (15) varyingz; // varying w/ null termination
@@ -276,153 +276,153 @@ describe("PL/I Parsing tests", () => {
  declare B char(3) varyingz init ( 'abc' ); // not equal to the one before by the way, null term is not used in varyingz for comparisons, even though it's there implicitly
  dcl Z char(3) nonvarying init('abc');
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("char declaration w/ overflow assignment", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("char declaration w/ overflow assignment", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare Subject char(10);
  Subject = 'Transformations'; // will truncate the last 5 chars, emitting a warning (but valid nonetheless)
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("arbitrary length char decl", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("arbitrary length char decl", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl VAL char(*) value('Some text that runs on and on');
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("nested quotes char decl", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("nested quotes char decl", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare User1 character (30) init('Shakespeare''s "Hamlet"');
  declare User2 character (30) init("Shakespeare's ""Hamlet""");
  declare User3 character (30) init('/* blah */');
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Bit declarations", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Bit declarations", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare S bit (64); // 64 bit var
  declare Code bit(10);
  Code = '110011'B;
  Code = '1100110000'B;
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Format constants", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Format constants", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  Prntexe: format
     ( column(20),A(15), column(40),A(15), column(60),A(15) );
  Prntstf: format
     ( column(20),A(10), column(35),A(10), column(50),A(10) );
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Attribute declarations", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Attribute declarations", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare Account1 file variable, // file var
  Account2 file automatic, // file var too
  File1 file, // file constant
  File2 file; // file constant
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Value List declaration", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Value List declaration", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl cmonth char(3)
             valuelist( 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
                          'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' );
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("value list from declaration", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("value list from declaration", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl 1 a,
     2 b fixed bin value(31),
     2 c fixed bin value(28),
     2 d fixed bin value(30);
  dcl x fixed bin valuelistfrom a;
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    // Handle as validation error
-    //         test.fails('fails with duplicate value in value list', async () => {
-    //             const doc: LangiumDocument<PliProgram> = await parseStmts(`
-    //  dcl 1 a,
-    //     2 b fixed bin value(31),
-    //     2 d fixed bin value(31);
-    //  dcl x fixed bin valuelistfrom a;
-    // `);
-    //             expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    //             expect(doc.parseResult.parserErrors).toHaveLength(0);
-    //         });
+        // Handle as validation error
+        //         test.fails('fails with duplicate value in value list', async () => {
+        //             const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        //  dcl 1 a,
+        //     2 b fixed bin value(31),
+        //     2 d fixed bin value(31);
+        //  dcl x fixed bin valuelistfrom a;
+        // `);
+        //             expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        //             expect(doc.parseResult.parserErrors).toHaveLength(0);
+        //         });
 
-    test.fails(
-      "value list is too long to handle in compiler correctly",
-      async () => {
-        const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test.fails(
+            "value list is too long to handle in compiler correctly",
+            async () => {
+                const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl 1 a, 2 b fixed bin value(31), 2 c fixed bin value(28), 2 d fixed bin value(31);
  dcl x fixed bin valuelistfrom a;
 `);
-        expect(doc.parseResult.lexerErrors).toHaveLength(0);
-        expect(doc.parseResult.parserErrors).toHaveLength(0);
-      },
-    );
+                expect(doc.parseResult.lexerErrors).toHaveLength(0);
+                expect(doc.parseResult.parserErrors).toHaveLength(0);
+            },
+        );
 
-    test("value range declaration", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("value range declaration", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  define alias numeric_month fixed bin(7) valuerange(1,12);
  dcl imonth type numeric_month; // must hold a val between 1 & 12 inclusive
  dcl cmonth char(3) // must be one of the 12 months listed
           valuelist( 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
                      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' );
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("multi-declaration", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("multi-declaration", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
     declare Result bit(3),
         A fixed decimal(1),
         B fixed binary (15), // precison lower than 15 will trigger a compiler warning, less than storage allows
         C character(2), D bit(4);
     `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
     });
-  });
 
-  test("pseduovariables", async () => {
-    // assigns into a sub-section of A from a sub-string of B
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("pseduovariables", async () => {
+        // assigns into a sub-section of A from a sub-string of B
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare A character(10),
         B character(30);
  substr(A,6,5) = substr(B,20,5);
 `);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  test("assignment from multi-declaration", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("assignment from multi-declaration", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare Result bit(4),
     A fixed decimal(1),
     B fixed binary (15),
@@ -433,13 +433,13 @@ describe("PL/I Parsing tests", () => {
     D = 1;
  Result = A + B < C & D;
 `);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  describe("Expressions", () => {
-    test("Assorted restricted expressions", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    describe("Expressions", () => {
+        test("Assorted restricted expressions", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  // from pg. 73
  dcl Max_names fixed bin value (1000),
     Name_size fixed bin value (30),
@@ -459,12 +459,12 @@ describe("PL/I Parsing tests", () => {
  dcl Ex     entry( dim(lbound(Ar):hbound(Ar)) pointer);
  dcl Identical_to_Ar( lbound(Ar):hbound(Ar) ) pointer;
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Simple arithmetic expressions", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Simple arithmetic expressions", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl A fixed bin(15), B fixed bin(15), C fixed bin(15);
  A = 5;
  B = 10;
@@ -474,12 +474,12 @@ describe("PL/I Parsing tests", () => {
  C = A / B;
  C = A ** B;
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
-    });
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
 
-    test("Function invocation", async () => {
-      const doc: LangiumDocument<PliProgram> = await parseStmts(`
+        test("Function invocation", async () => {
+            const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl A fixed bin(15), B fixed bin(15), Y fixed bin(15), X fixed bin(15);
  A = 5;
  B = 10;
@@ -491,13 +491,13 @@ describe("PL/I Parsing tests", () => {
     return(v1+v2);
  end ADD;
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
     });
-  });
 
-  test("Basic branching", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("Basic branching", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl A bit(4),
     D bit(5);
  A=1;
@@ -507,44 +507,44 @@ describe("PL/I Parsing tests", () => {
  X:;
  Y:;
 `);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  describe("Packages", () => {
-    test("Package with main routine", async () => {
-      const doc: LangiumDocument<PliProgram> = await parse(`
+    describe("Packages", () => {
+        test("Package with main routine", async () => {
+            const doc: LangiumDocument<PliProgram> = await parse(`
  Package_Demo: Package exports (T);
  T: PROCEDURE OPTIONS (MAIN);
  END T;
  end Package_Demo;
 `);
-      expect(doc.parseResult.lexerErrors).toHaveLength(0);
-      expect(doc.parseResult.parserErrors).toHaveLength(0);
+            expect(doc.parseResult.lexerErrors).toHaveLength(0);
+            expect(doc.parseResult.parserErrors).toHaveLength(0);
+        });
     });
-  });
 
-  test("simple PUT", async () => {
-    // output a string to the stdout
-    const doc: LangiumDocument<PliProgram> = await parseStmts(
-      ` put skip list('Hello ' || 'World');`,
-    );
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+    test("simple PUT", async () => {
+        // output a string to the stdout
+        const doc: LangiumDocument<PliProgram> = await parseStmts(
+            ` put skip list('Hello ' || 'World');`,
+        );
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  test("simple GET", async () => {
-    // read a string into a variable 'var'
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("simple GET", async () => {
+        // read a string into a variable 'var'
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl VAR fixed bin(15);
  get list(var);
 `);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  test("fetch", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("fetch", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl A entry;
  fetch A title('X');
  fetch A;
@@ -555,21 +555,21 @@ describe("PL/I Parsing tests", () => {
  fetch ProgA;
  call ProgA;
  release ProgA;`);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  test("BEGIN block", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("BEGIN block", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  B: begin;
  declare A fixed bin(15);
  end B;`);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  test.skip("Subscripted entry invocation", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test.skip("Subscripted entry invocation", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  declare (A,B,C,D,E) entry;
  declare F(5) entry variable initial (A,B,C,D,E);
  declare I fixed bin(15),
@@ -579,12 +579,12 @@ describe("PL/I Parsing tests", () => {
  do I = 1 to 5;
   call F(I) (X,Y,Z); // each entry call gets args x,y,z
  end;`);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  test("Optional args", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("Optional args", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
  dcl Vrtn entry (
     fixed bin,
     ptr optional,
@@ -599,16 +599,59 @@ describe("PL/I Parsing tests", () => {
  call Vrtn(10, *, 15.5);
  call Vrtn(10, addr(x), 15.5);
 `);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 
-  test("Block 27", async () => {
-    const doc: LangiumDocument<PliProgram> = await parseStmts(`
+    test("Block 27", async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
     /* Enterprise PL/I for z/OS Language Reference v6.1, pg.59 */
     A = '/* This is a constant, not a comment */' ;
     `);
-    expect(doc.parseResult.lexerErrors).toHaveLength(0);
-    expect(doc.parseResult.parserErrors).toHaveLength(0);
-  });
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
+
+    /**
+     * Verifies we can parse 'returns(ordinal `type` byvalue)` cases
+     */
+    test('parse returns ordinal by value', async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
+ testpackage: package;
+
+ define ordinal day (
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+    Sunday
+ ) prec(15);
+
+ /* should be able to parse return w/ ordinal correctly */
+ get_day: proc() returns(ordinal day byvalue);
+    return( Friday );
+ end get_day;
+
+ end testpackage;
+        `);
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
+
+    /**
+     * Verifies that numbers like '010101'xn are parsable
+     */
+    // TODO rename this one
+    test('parses xn hex vals', async () => {
+        const doc: LangiumDocument<PliProgram> = await parseStmts(`
+ MAINPR: procedure options (main);
+    dcl x fixed bin(31) init(0);
+    x = '0000ffff'xn;
+ end MAINPR;
+        `);
+        expect(doc.parseResult.lexerErrors).toHaveLength(0);
+        expect(doc.parseResult.parserErrors).toHaveLength(0);
+    });
 });

--- a/packages/language/test/validating.test.ts
+++ b/packages/language/test/validating.test.ts
@@ -9,6 +9,10 @@
  *
  */
 
+// TODO @montymxb Jan. 24th, 2025
+// - test support for alignment attributes, which are mutually exclusive ALIGNED & UNALIGNED (valid in returns attribute context)
+// ex. `xyz: proc returns ( aligned unaligned bit(4) )`
+
 import { describe, test } from "vitest";
 // import { beforeAll, describe, expect, test } from "vitest";
 // import { EmptyFileSystem, type LangiumDocument } from "langium";


### PR DESCRIPTION
%statements & %directives remain outstanding issues that weren't handled. Those can be blanket covered using STRING_TERM, but that feels a bit too much of a cover, and will probably mask something else by accident. I can follow up later with specific directives/statements that need % variant support as well.

Adding additional tests (and corrections) for properly parsing examples based on material from IBM's PLI course. It's been noted that a few of those examples still don't parse w/ the current extension. The cases that don't are fairly distinct, so this PR extracts those problems and creates distinct test cases based on those (without using the original course material itself).

One issue has been resolved already regarding how hex fixed-point constants are parsed. Although we had `xn` as a recognized extension to a a given terminal, there was a preceding `x` alternative that would be greedily accepted instead. Shifting the order was enough to resolve this, and I moved `xu` as well.